### PR TITLE
Update example Makefiles

### DIFF
--- a/examples/simple-menu/Makefile
+++ b/examples/simple-menu/Makefile
@@ -15,7 +15,7 @@ all: build push install
 build: compile pack
 
 compile:
-	mkdir -p build/files/code
+	mkdir -p build/files/code build/files/config
 	jerry-snapshot generate -f '' ${source_file} -o ${snapshot_file}
 
 pack:

--- a/examples/snake/Makefile
+++ b/examples/snake/Makefile
@@ -15,7 +15,7 @@ all: build push install
 build: compile pack
 
 compile:
-	mkdir -p build/files/code
+	mkdir -p build/files/code build/files/config
 	jerry-snapshot generate -f '' ${source_file} -o ${snapshot_file}
 
 pack:

--- a/examples/timer/Makefile
+++ b/examples/timer/Makefile
@@ -15,7 +15,7 @@ all: build push install
 build: compile pack
 
 compile:
-	mkdir -p build/files/code
+	mkdir -p build/files/code build/files/config
 	jerry-snapshot generate -f '' ${source_file} -o ${snapshot_file}
 
 pack:


### PR DESCRIPTION
The Makefiles for the examples needed to be updated for the modified pack.py. Without a "config" directory, it would give an error and fail to build the wapp file.