### PR TITLE
Fix make for versions of GB with targetSDK>=31

### DIFF
--- a/examples/simple-menu/Makefile
+++ b/examples/simple-menu/Makefile
@@ -5,9 +5,9 @@ snapshot_file := build/files/code/${identifier}
 tools_dir := $(if $(WATCH_SDK_PATH),$(WATCH_SDK_PATH),../../)
 package_file := ${identifier}.wapp
 package_path := build/${package_file}
-
 adb_target := 192.168.0.192:5555
-adb_target_dir := /sdcard/${package_file}
+export_import_dir := /sdcard/Android/data/nodomain.freeyourgadget.gadgetbridge/files
+adb_target_dir := ${export_import_dir}/make/${package_file}
 
 .PHONY: all build compile pack push connect install clean
 
@@ -22,16 +22,20 @@ pack:
 	python3 ${tools_dir}tools/pack.py -i build/ -o ${package_path}
 
 push:
-	adb push ${package_path} ${adb_target_dir}
+	@if ! adb push ${package_path} ${adb_target_dir}; then \
+		echo "Error: Failed to push files."; \
+		echo "Check that your phone is connected via adb, and then that the path of the import export directory under the data management screen in Gadgetbridge, corresponds to the export_import_dir in the makefile."; \
+		exit 1; \
+	fi
 
 connect:
 	adb connect ${adb_target}
 
 install:
 	adb shell am broadcast \
-    -a "nodomain.freeyourgadget.gadgetbridge.Q_UPLOAD_FILE" \
-    --es EXTRA_HANDLE APP_CODE \
-    --es EXTRA_PATH "${adb_target_dir}" \
+	-a "nodomain.freeyourgadget.gadgetbridge.Q_UPLOAD_FILE" \
+	--es EXTRA_HANDLE APP_CODE \
+	--es EXTRA_PATH "${adb_target_dir}" \
 	--ez EXTRA_GENERATE_FILE_HEADER false
 
 clean:

--- a/examples/snake/Makefile
+++ b/examples/snake/Makefile
@@ -5,9 +5,9 @@ snapshot_file := build/files/code/${identifier}
 tools_dir := $(if $(WATCH_SDK_PATH),$(WATCH_SDK_PATH),../../)
 package_file := ${identifier}.wapp
 package_path := build/${package_file}
-
 adb_target := 192.168.0.192:5555
-adb_target_dir := /sdcard/${package_file}
+export_import_dir := /sdcard/Android/data/nodomain.freeyourgadget.gadgetbridge/files
+adb_target_dir := ${export_import_dir}/make/${package_file}
 
 .PHONY: all build compile pack push connect install clean
 
@@ -22,16 +22,20 @@ pack:
 	python3 ${tools_dir}tools/pack.py -i build/ -o ${package_path}
 
 push:
-	adb push ${package_path} ${adb_target_dir}
+	@if ! adb push ${package_path} ${adb_target_dir}; then \
+		echo "Error: Failed to push files."; \
+		echo "Check that your phone is connected via adb, and then that the path of the import export directory under the data management screen in Gadgetbridge, corresponds to the export_import_dir in the makefile."; \
+		exit 1; \
+	fi
 
 connect:
 	adb connect ${adb_target}
 
 install:
 	adb shell am broadcast \
-    -a "nodomain.freeyourgadget.gadgetbridge.Q_UPLOAD_FILE" \
-    --es EXTRA_HANDLE APP_CODE \
-    --es EXTRA_PATH "${adb_target_dir}" \
+	-a "nodomain.freeyourgadget.gadgetbridge.Q_UPLOAD_FILE" \
+	--es EXTRA_HANDLE APP_CODE \
+	--es EXTRA_PATH "${adb_target_dir}" \
 	--ez EXTRA_GENERATE_FILE_HEADER false
 
 clean:

--- a/examples/timer/Makefile
+++ b/examples/timer/Makefile
@@ -5,10 +5,9 @@ snapshot_file := build/files/code/${identifier}
 tools_dir := $(if $(WATCH_SDK_PATH),$(WATCH_SDK_PATH),../../)
 package_file := ${identifier}.wapp
 package_path := build/${package_file}
-
 adb_target := 192.168.0.192:5555
-adb_target_dir := /sdcard/q
-adb_target_file := ${adb_target_dir}/${package_file}
+export_import_dir := /sdcard/Android/data/nodomain.freeyourgadget.gadgetbridge/files
+adb_target_dir := ${export_import_dir}/make/${package_file}
 
 .PHONY: all build compile pack push connect install clean
 
@@ -23,17 +22,20 @@ pack:
 	python3 ${tools_dir}tools/pack.py -i build/ -o ${package_path}
 
 push:
-	adb shell mkdir -p ${adb_target_dir} 
-	adb push ${package_path} ${adb_target_file}
+	@if ! adb push ${package_path} ${adb_target_dir}; then \
+		echo "Error: Failed to push files."; \
+		echo "Check that your phone is connected via adb, and then that the path of the import export directory under the data management screen in Gadgetbridge, corresponds to the export_import_dir in the makefile."; \
+		exit 1; \
+	fi
 
 connect:
 	adb connect ${adb_target}
 
 install:
 	adb shell am broadcast \
-    -a "nodomain.freeyourgadget.gadgetbridge.Q_UPLOAD_FILE" \
-    --es EXTRA_HANDLE APP_CODE \
-    --es EXTRA_PATH "${adb_target_file}" \
+	-a "nodomain.freeyourgadget.gadgetbridge.Q_UPLOAD_FILE" \
+	--es EXTRA_HANDLE APP_CODE \
+	--es EXTRA_PATH "${adb_target_dir}" \
 	--ez EXTRA_GENERATE_FILE_HEADER false
 
 clean:


### PR DESCRIPTION
Copy-paste from https://codeberg.org/Freeyourgadget/fossil-hr-watchface/pulls/11

----------------------------------
GB has updated `targetSDK` to 31, which means it can no longer access files that are located outside it's own folder. A side effect of this is that we can no longer automatically install watchfaces by just typing make.

This PR makes it push directly to the GB directory, which means that it can work automatically again.
In the case that the `/sdcard/Android/data/nodomain.freeyourgadget.gadgetbridge/files` path is not universal, I have added a printed message directing the user to how they can find the correct path for their device from the GB app.